### PR TITLE
set `shm_size: '2gb'`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
 
   shell:
     image: visualatomjl
+    shm_size: '2gb'
     container_name: visualatomjl-julia
     volumes:
       - ./:/workspace/VisualAtom.jl


### PR DESCRIPTION
This pr add `shm_size: '2gb'` in `docker-compose.yml` to prevent from happing `Unhandled Task Error`.