### PR TITLE
Use `@distributed (+) for ... ` expression 

### DIFF
--- a/run.jl
+++ b/run.jl
@@ -20,10 +20,11 @@ function generate_dataset(
     num_instances = config.num_instances
 
     @info "Generate VisualAtom dataset" num_categories num_instances nprocs()
-    @showprogress @distributed for category_id in 0:(num_categories-1)
+    cnt = @showprogress "Generating..." @distributed (+) for category_id in 0:(num_categories-1)
         generate_instances(config; save_root, category_id, num_instances)
+        true
     end
-    println("Done! checkout $(save_root)")
+    println("Done! $cnt classes should be generated in $(save_root) directory")
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__


### PR DESCRIPTION
There is a case that happens `Still Unhandled Task Error`. This PR rewrites the loop expression in `run.jl` so that the main process waits until all computation are complete.